### PR TITLE
[occm 1.22] Support specifying a sort order for node addresses

### DIFF
--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -168,6 +168,13 @@ The options in `Global` section are used for openstack-cloud-controller-manager 
   The name of Neutron external network. openstack-cloud-controller-manager uses this option when getting the external IP of the Kubernetes node. Can be specified multiple times. Specified network names will be ORed. Default: ""
 * `internal-network-name`
   The name of Neutron internal network. openstack-cloud-controller-manager uses this option when getting the internal IP of the Kubernetes node, this is useful if the node has multiple interfaces. Can be specified multiple times. Specified network names will be ORed. Default: ""
+* `address-sort-order`
+  This configuration key influences the way the provider reports the node addresses to the Kubernetes node resource. The default order depends on the hard-coded order the provider queries the addresses and what the cloud returns, which does not guarantee a specific order.
+
+  To override this behavior it is possible to specify a comma separated list of CIDRs. Essentially, this will sort and group all addresses matching a CIDR in a prioritized manner, where the first item having a higher priority than the last. All non-matching addresses will remain in the same order they are already in.
+
+  For example, this option can be useful when having multiple or dual-stack interfaces attached to a node and needing a user-controlled, deterministic way of sorting the addresses.
+  Default: ""
 
 ###  Load Balancer
 

--- a/hack/build-image.sh
+++ b/hack/build-image.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+ARCH=amd64 \
+GOOS=linux \
+REGISTRY=docker.io/infonova \
+VERSION=1.22.1-bp-fd2a9277-1 \
+make image-openstack-cloud-controller-manager

--- a/pkg/openstack/instances_test.go
+++ b/pkg/openstack/instances_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestBuildAddressSortOrderList(t *testing.T) {
+	var emptyList []*net.IPNet
+
+	_, cidrIPv4, _ := net.ParseCIDR("192.168.0.0/16")
+	_, cidrIPv6, _ := net.ParseCIDR("2001:4800:790e::/64")
+
+	emptyOption := ""
+	multipleInvalidOptions := "InvalidOption, AnotherInvalidOption"
+	multipleOptionsWithInvalidOption := fmt.Sprintf("%s, %s, %s", cidrIPv4, multipleInvalidOptions, cidrIPv6)
+
+	tests := map[string][]*net.IPNet{
+		emptyOption:                      emptyList,
+		multipleInvalidOptions:           emptyList,
+		multipleOptionsWithInvalidOption: {cidrIPv4, cidrIPv6},
+	}
+
+	for option, want := range tests {
+		actual := buildAddressSortOrderList(option)
+		if !reflect.DeepEqual(want, actual) {
+			t.Errorf("assignSortOrderPriorities returned incorrect value for '%v', want %+v but got %+v", option, want, actual)
+		}
+	}
+}
+
+func TestGetSortPriority(t *testing.T) {
+	_, cidrIPv4, _ := net.ParseCIDR("192.168.100.0/24")
+	_, cidrIPv6, _ := net.ParseCIDR("2001:4800:790e::/64")
+
+	list := []*net.IPNet{cidrIPv4, cidrIPv6}
+	t.Log(list)
+	tests := map[string]int{
+		"":                     noSortPriority,
+		"some-host.exam.ple":   noSortPriority,
+		"2001:4800:790e::82a8": 1,
+		"2001:cafe:babe::82a8": noSortPriority,
+		"192.168.100.200":      2,
+		"192.168.101.123":      noSortPriority,
+	}
+
+	for option, want := range tests {
+		actual := getSortPriority(list, option)
+		if !reflect.DeepEqual(want, actual) {
+			t.Errorf("assignSortOrderPriorities returned incorrect value for '%v', want %+v but got %+v", option, want, actual)
+		}
+	}
+}
+
+func executeSortNodeAddressesTest(t *testing.T, addressSortOrder string, want []v1.NodeAddress) {
+	addresses := []v1.NodeAddress{
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "192.168.0.1"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
+		{Type: v1.NodeInternalIP, Address: "172.16.0.1"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeInternalIP, Address: "50.56.176.37"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.exam.ple"},
+	}
+
+	sortNodeAddresses(addresses, addressSortOrder)
+
+	t.Logf("addresses are %v", addresses)
+	if !reflect.DeepEqual(want, addresses) {
+		t.Fatalf("sortNodeAddresses returned incorrect value, want %v", want)
+	}
+}
+
+func TestSortNodeAddressesWithAnInvalidCIDR(t *testing.T) {
+	addressSortOrder := "10.0.0.0/244"
+
+	want := []v1.NodeAddress{
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "192.168.0.1"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
+		{Type: v1.NodeInternalIP, Address: "172.16.0.1"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeInternalIP, Address: "50.56.176.37"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.exam.ple"},
+	}
+
+	executeSortNodeAddressesTest(t, addressSortOrder, want)
+}
+
+func TestSortNodeAddressesWithOneIPv4CIDR(t *testing.T) {
+	addressSortOrder := "10.0.0.0/8"
+
+	want := []v1.NodeAddress{
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "192.168.0.1"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "172.16.0.1"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "50.56.176.37"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.exam.ple"},
+	}
+
+	executeSortNodeAddressesTest(t, addressSortOrder, want)
+}
+
+func TestSortNodeAddressesWithOneIPv6CIDR(t *testing.T) {
+	addressSortOrder := "fd08:1374:fcee:916b::/64"
+
+	want := []v1.NodeAddress{
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "192.168.0.1"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
+		{Type: v1.NodeInternalIP, Address: "172.16.0.1"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeInternalIP, Address: "50.56.176.37"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.exam.ple"},
+	}
+
+	executeSortNodeAddressesTest(t, addressSortOrder, want)
+}
+
+func TestSortNodeAddressesWithMultipleCIDRs(t *testing.T) {
+	addressSortOrder := "10.0.0.0/8, 172.16.0.0/16, 192.168.0.0/24, fd08:1374:fcee:916b::/64, 50.56.176.0/24, 2001:cafe:babe::/64"
+
+	want := []v1.NodeAddress{
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
+		{Type: v1.NodeInternalIP, Address: "172.16.0.1"},
+		{Type: v1.NodeInternalIP, Address: "192.168.0.1"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeInternalIP, Address: "50.56.176.37"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.exam.ple"},
+	}
+
+	executeSortNodeAddressesTest(t, addressSortOrder, want)
+}

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -118,6 +118,7 @@ type NetworkingOpts struct {
 	IPv6SupportDisabled bool     `gcfg:"ipv6-support-disabled"`
 	PublicNetworkName   []string `gcfg:"public-network-name"`
 	InternalNetworkName []string `gcfg:"internal-network-name"`
+	AddressSortOrder    string   `gcfg:"address-sort-order"`
 }
 
 // RouterOpts is used for Neutron routes

--- a/pkg/openstack/openstack_test.go
+++ b/pkg/openstack/openstack_test.go
@@ -830,6 +830,90 @@ func TestNodeAddressesIPv6Disabled(t *testing.T) {
 	}
 }
 
+func TestNodeAddressesWithAddressSortOrderOptions(t *testing.T) {
+	srv := servers.Server{
+		Status:     "ACTIVE",
+		HostID:     "29d3c8c896a45aa4c34e52247875d7fefc3d94bbcc9f622b5d204362",
+		AccessIPv4: "50.56.176.99",
+		AccessIPv6: "2001:4800:790e:510:be76:4eff:fe04:82a8",
+		Addresses: map[string]interface{}{
+			"private": []interface{}{
+				map[string]interface{}{
+					"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:7c:1b:2b",
+					"version":                 float64(4),
+					"addr":                    "10.0.0.32",
+					"OS-EXT-IPS:type":         "fixed",
+				},
+				map[string]interface{}{
+					"version":         float64(4),
+					"addr":            "50.56.176.36",
+					"OS-EXT-IPS:type": "floating",
+				},
+				map[string]interface{}{
+					"version": float64(4),
+					"addr":    "10.0.0.31",
+					// No OS-EXT-IPS:type
+				},
+			},
+			"public": []interface{}{
+				map[string]interface{}{
+					"version": float64(4),
+					"addr":    "50.56.176.35",
+				},
+				map[string]interface{}{
+					"version": float64(6),
+					"addr":    "2001:4800:780e:510:be76:4eff:fe04:84a8",
+				},
+			},
+		},
+		Metadata: map[string]string{
+			"name":       "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy",
+			TypeHostName: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal",
+		},
+	}
+
+	networkingOpts := NetworkingOpts{
+		PublicNetworkName: []string{"public"},
+		AddressSortOrder:  "10.0.0.0/8, 50.56.176.0/24, 2001:4800::/32",
+	}
+
+	interfaces := []attachinterfaces.Interface{
+		{
+			PortState: "ACTIVE",
+			FixedIPs: []attachinterfaces.FixedIP{
+				{
+					IPAddress: "10.0.0.32",
+				},
+				{
+					IPAddress: "10.0.0.31",
+				},
+			},
+		},
+	}
+
+	addrs, err := nodeAddresses(&srv, interfaces, networkingOpts)
+	if err != nil {
+		t.Fatalf("nodeAddresses returned error: %v", err)
+	}
+
+	t.Logf("addresses are %v", addrs)
+
+	want := []v1.NodeAddress{
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
+	}
+
+	if !reflect.DeepEqual(want, addrs) {
+		t.Errorf("nodeAddresses returned incorrect value, want %v", want)
+	}
+}
+
 func TestNewOpenStack(t *testing.T) {
 	cfg := ConfigFromEnv()
 	testConfigFromEnv(t, &cfg)


### PR DESCRIPTION


This intruduces a configuration key which influences the way the
provider reports the node addresses to the Kubernetes node resource.

The default order depends on the hard-coded order the provider queries
the addresses and what the cloud returns, which does not guarantee a
specific order.

To override this behavior it is possible to specify a comma separated
list of CIDRs. Essentially, this will sort and group all addresses
matching a CIDR in a prioritized manner, where the first item having a
higher priority than the last. All non-matching addresses will remain in
the same order they are already in.

For example, this option can be useful when having multiple or
dual-stack interfaces attached to a node and needing a user-controlled,
deterministic way of sorting the addresses.
